### PR TITLE
Add theme and color schemas in principal view (#27)

### DIFF
--- a/app/src/main/java/com/una/arshopping/view/components/aside/button/Button.kt
+++ b/app/src/main/java/com/una/arshopping/view/components/aside/button/Button.kt
@@ -24,10 +24,10 @@ fun Button(
     text: String,
     onClick: () -> Unit,
     contentColor: Color = Color.White,
-    backgroundColor: Color = Color(0xFFB0CCDE),
     modifier: Modifier = Modifier,
     @DrawableRes iconId: Int,
-    iconContentDescription: String? = null
+    iconContentDescription: String? = null,
+    themeNumber : Int = 0
 ) {
     val styles = Styles()
     Button(
@@ -35,8 +35,8 @@ fun Button(
         modifier = modifier,
         shape = RoundedCornerShape(12.dp),
         colors = ButtonDefaults.buttonColors(
-            containerColor = backgroundColor.copy(alpha = 0.95f),
-            contentColor = contentColor
+            containerColor = if (themeNumber == 1 || themeNumber == 0) Color(0x80D9D9D9) else Color(0x80FFFFFF),
+            contentColor = contentColor,
         )
     ) {
 

--- a/app/src/main/java/com/una/arshopping/view/components/aside/button/DarkModeButton.kt
+++ b/app/src/main/java/com/una/arshopping/view/components/aside/button/DarkModeButton.kt
@@ -19,7 +19,9 @@ import com.una.arshopping.R
 @Composable
 fun DarkModeButton(){
     FilledIconButton(
-        onClick = {  },
+        onClick = {
+
+        },
         modifier = Modifier
             .size(42.dp)
             .border(

--- a/app/src/main/java/com/una/arshopping/view/components/aside/content/AsideBox.kt
+++ b/app/src/main/java/com/una/arshopping/view/components/aside/content/AsideBox.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.una.arshopping.R
+import com.una.arshopping.repository.gelAllTheme
 import com.una.arshopping.styles.Styles
 import com.una.arshopping.view.components.aside.button.Button
 import com.una.arshopping.view.components.myprofile.MyProfileActivity
@@ -30,8 +31,13 @@ import com.una.arshopping.view.components.preferences.PreferencesActivity
 
 @Composable
 fun AsideBox() {
-    val styles = Styles()
     val context = LocalContext.current
+    /**************
+     * define styles global
+     */
+    val themeNumber = gelAllTheme(context)
+    val styles = Styles()
+    val fontColor = if (themeNumber == 1 || themeNumber == 0) Color.Black else Color.White
     Box(
         Modifier
             .padding(start = 5.dp, top = 20.dp)
@@ -60,7 +66,7 @@ fun AsideBox() {
                     style = TextStyle(
                         fontFamily = styles.fontFamily,
                         fontSize = 25.sp,
-                        color = Color.Black
+                        color = fontColor
                     )
                 )
 
@@ -88,11 +94,15 @@ fun AsideBox() {
                         iconId = iconId,
                         iconContentDescription = label,
                         onClick = action,
-                        contentColor = Color.Black,
+                        contentColor = fontColor,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(50.dp)
                             .padding(horizontal = 25.dp)
+                            .border(1.dp,Color.White, RoundedCornerShape(10.dp)),
+                        themeNumber = themeNumber
+
+
                     )
                 }
             }

--- a/app/src/main/java/com/una/arshopping/view/components/aside/content/Background.kt
+++ b/app/src/main/java/com/una/arshopping/view/components/aside/content/Background.kt
@@ -1,29 +1,47 @@
 package com.una.arshopping.view.components.aside.content
-
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.una.arshopping.view.components.aside.button.DarkModeButton
+import com.una.arshopping.repository.gelAllTheme
+import com.una.arshopping.repository.updateTheme
+import com.una.arshopping.styles.Styles
+import com.una.arshopping.view.components.login.themeschema.ThemeSchema
+import com.una.arshopping.view.components.main.PrincipalActivity
 
 @Composable
 fun Background() {
+    /**
+     * get to local storage theme and set it
+     */
+    val context = LocalContext.current
+    var numberTheme by remember { mutableIntStateOf(gelAllTheme(context)) }
+    var colorBackground =
+        if (numberTheme == 1 || numberTheme == 0) Styles().colorLightBackground else Styles().colorDarkBackground
+    Log.d("THEME_FETCH", "theme: $colorBackground")
 
     Box(
         Modifier
             .border(width = 1.dp, color = Color(0xFFFFFFFF))
             .width(331.dp)
-            .height(1000.dp)
-            .background(color = Color(0xED90D5FF))
+            .fillMaxHeight()
+            .background(colorBackground)
 
     ) {
         Divisor()
@@ -34,7 +52,26 @@ fun Background() {
                 .padding(bottom = 8.dp),
             contentAlignment = Alignment.BottomCenter
         ) {
-            DarkModeButton()
+            Box(
+                Modifier.size(width = 70.dp, height = 50.dp)
+            ) {
+                ThemeSchema(
+                    colorBackground = {
+                        if (colorBackground == Styles().colorLightBackground) {
+                            colorBackground = Styles().colorDarkBackground
+                            updateTheme(context, 2)
+                            numberTheme = 2
+                        } else {
+                            colorBackground = Styles().colorLightBackground
+                            updateTheme(context, 1)
+                            numberTheme = 1
+                        }
+                        context as PrincipalActivity
+                        context.recreate()
+                    },
+                    backgroundColor = colorBackground
+                )
+            }
         }
 
     }

--- a/app/src/main/java/com/una/arshopping/view/components/aside/content/MainBox.kt
+++ b/app/src/main/java/com/una/arshopping/view/components/aside/content/MainBox.kt
@@ -2,7 +2,9 @@ package com.una.arshopping.view.components.aside.content
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.tooling.preview.Preview
+import com.una.arshopping.styles.Styles
 
 @Composable
 fun MainBox() {
@@ -10,13 +12,6 @@ fun MainBox() {
     Box {
         Background()
         AsideBox()
-
     }
 
 }
-/*
-@Preview(showBackground = true)
-@Composable
-fun PreviewMainBox() {
-    MainBox()
-}*/

--- a/app/src/main/java/com/una/arshopping/view/components/main/PrincipalActivity.kt
+++ b/app/src/main/java/com/una/arshopping/view/components/main/PrincipalActivity.kt
@@ -1,13 +1,18 @@
 package com.una.arshopping.view.components.main
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -16,17 +21,54 @@ import com.una.arshopping.styles.Styles
 import com.una.arshopping.view.components.main.layout.MainLayout
 import com.una.arshopping.viewmodel.ProductViewModel
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import com.una.arshopping.repository.gelAllTheme
 
 
 class PrincipalActivity : ComponentActivity() {
     private lateinit var productViewModel: ProductViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        /******************
+         * get the products from the database or localhost
+         */
         productViewModel = ViewModelProvider(this)[ProductViewModel::class.java]
         productViewModel.getProduct(context = this)
         enableEdgeToEdge()
         setContent {
-            MainScreen(productViewModel)
+            AnimatedEntry{
+                MainScreen(productViewModel)
+            }
+        }
+    }
+
+    @Composable
+    fun AnimatedEntry(content: @Composable () -> Unit) {
+        var visible by remember { mutableStateOf(false) }
+
+
+        LaunchedEffect(Unit) {
+            visible = true
+        }
+
+        val alpha by animateFloatAsState(
+            targetValue = if (visible) 1f else 0f,
+            animationSpec = tween(durationMillis = 600)
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(alpha = alpha)
+        ) {
+            content()
         }
     }
 
@@ -44,15 +86,20 @@ class PrincipalActivity : ComponentActivity() {
         /**
          * get to local storage theme and set it
          */
-
-
+        val context = LocalContext.current
+        var numberTheme by remember { mutableIntStateOf(gelAllTheme(context)) }
+        var colorBackground =
+            if (numberTheme == 1 || numberTheme == 0) Styles().colorLightBackground else Styles().colorDarkBackground
+        Log.d("THEME_FETCH", "theme: $colorBackground")
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
-                .background(Styles().colorLightBackground)
+                .background(colorBackground)
                 .fillMaxSize()
         ) {
-            MainLayout(products)
+            MainLayout(
+                productResponse = products
+            )
         }
     }
 }

--- a/app/src/main/java/com/una/arshopping/view/components/main/layout/MainLayout.kt
+++ b/app/src/main/java/com/una/arshopping/view/components/main/layout/MainLayout.kt
@@ -1,13 +1,9 @@
 package com.una.arshopping.view.components.main.layout
 
 import StoreLabel
-import android.transition.Fade
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.*
@@ -71,7 +67,6 @@ fun MainLayout(
                     .zIndex(2f)
             ) {
                 MainBox()
-
                 Blur(onTapOutside = {
                     isMenuOpen = false
                 })


### PR DESCRIPTION
* Delete MainBox preview and adjust styles in Background, PrincipalActivity, and DarkModeButton

The MainBox preview has been removed.

The Background component now:
- Fetches the current theme from local storage.
- Sets its background color based on the retrieved theme.
- Includes a ThemeSchema component to allow theme switching.

The PrincipalActivity now:
- Fetches the current theme from local storage.
- Sets its background color based on the retrieved theme.

The DarkModeButton's onClick handler has been cleared for future implementation.

* -- Implemented theme change functionality in `Background.kt` allowing users to switch themes and apply changes by recreating the `PrincipalActivity`. -- Added an animated entry transition to `PrincipalActivity` for a smoother visual experience when the activity starts. -- Refactored `PrincipalActivity` to correctly fetch and apply the theme from local storage using `remember` and `mutableIntStateOf`. -- Minor UI adjustments in `MainBox.kt` and `MainLayout.kt`.

* -- Implemented theme change functionality in `Background.kt` allowing users to switch themes and apply changes by recreating the `PrincipalActivity`. -- Added an animated entry transition to `PrincipalActivity` for a smoother visual experience when the activity starts. -- Refactored `PrincipalActivity` to correctly fetch and apply the theme from local storage using `remember` and `mutableIntStateOf`. -- Minor UI adjustments in `MainBox.kt` and `MainLayout.kt`.

* Improve code comments in AsideBox.kt